### PR TITLE
chore(release): 0.2.1 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+## [0.2.1](https://github.com/DavidSanwald/react-use-brush/compare/v0.2.0...v0.2.1) (2019-11-23)
+
+
+### Bug Fixes
+
+* add pointerEvents: none to brush rect| ([5ba9b72](https://github.com/DavidSanwald/react-use-brush/commit/5ba9b72004f7db8a9511a2eba02daa29a842f844))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-use-brush",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-use-brush",
-  "version": "0.0.0-development",
+  "version": "0.2.1",
   "license": "MIT",
   "author": "DavidSanwald",
   "repository": {


### PR DESCRIPTION
## [0.2.1](https://github.com/DavidSanwald/react-use-brush/compare/v0.2.0...v0.2.1) (2019-11-23)

### Bug Fixes

* add pointerEvents: none to brush rect| ([5ba9b72](https://github.com/DavidSanwald/react-use-brush/commit/5ba9b72004f7db8a9511a2eba02daa29a842f844))